### PR TITLE
Fixes #55

### DIFF
--- a/src/components/artifacts/ArtifactRenderer.tsx
+++ b/src/components/artifacts/ArtifactRenderer.tsx
@@ -1,22 +1,21 @@
-import { v4 as uuidv4 } from "uuid";
-import { useState, useEffect, useCallback, useRef } from "react";
-import { Button } from "../ui/button";
-import { Input } from "../ui/input";
-import { CircleArrowUp, Eye, PencilLine } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { GraphInput } from "@/hooks/useGraph";
+import { convertToOpenAIFormat } from "@/lib/convert_messages";
+import { newlineToCarriageReturn } from "@/lib/normalize_string";
 import { cn } from "@/lib/utils";
 import { Artifact, ProgrammingLanguageOptions, Reflections } from "@/types";
-import { GraphInput } from "@/hooks/useGraph";
-import { BaseMessage, HumanMessage } from "@langchain/core/messages";
-import { convertToOpenAIFormat } from "@/lib/convert_messages";
-import { X } from "lucide-react";
-import { ActionsToolbar, CodeToolBar } from "./actions_toolbar";
-import { TextRenderer } from "./TextRenderer";
-import { CodeRenderer } from "./CodeRenderer";
-import { TooltipIconButton } from "../ui/assistant-ui/tooltip-icon-button";
-import { useToast } from "@/hooks/use-toast";
 import { EditorView } from "@codemirror/view";
-import { newlineToCarriageReturn } from "@/lib/normalize_string";
+import { BaseMessage, HumanMessage } from "@langchain/core/messages";
+import { CircleArrowUp, Eye, PencilLine, X } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { v4 as uuidv4 } from "uuid";
 import { ReflectionsDialog } from "../reflections-dialog/ReflectionsDialog";
+import { TooltipIconButton } from "../ui/assistant-ui/tooltip-icon-button";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { ActionsToolbar, CodeToolBar } from "./actions_toolbar";
+import { CodeRenderer } from "./CodeRenderer";
+import { TextRenderer } from "./TextRenderer";
 
 export interface ArtifactRendererProps {
   artifact: Artifact | undefined;
@@ -290,7 +289,7 @@ export function ArtifactRenderer(props: ArtifactRendererProps) {
         <div
           className={cn(
             "relative min-h-full",
-            props.artifact.type === "code" ? "min-w-full" : "min-w-full px-4"
+            props.artifact.type === "code" ? "min-w-full" : "min-w-full"
           )}
         >
           <div className="h-[85%]" ref={markdownRef}>

--- a/src/components/artifacts/TextRenderer.module.css
+++ b/src/components/artifacts/TextRenderer.module.css
@@ -1,6 +1,7 @@
 .mdEditorCustom {
   height: 100% !important;
   overflow: hidden;
+  border-radius: 0%;
 }
 
 .mdEditorCustom :global(.w-md-editor) {
@@ -21,7 +22,7 @@
 
 .mdEditorCustom :global(.w-md-editor-preview) {
   box-shadow: none !important;
-  border-left: 1px solid #e0e0e0;
+  /* border-left: 1px solid #e0e0e0; */
 }
 
 .mdEditorCustom :global(.w-md-editor-toolbar) {

--- a/src/components/artifacts/TextRenderer.module.css
+++ b/src/components/artifacts/TextRenderer.module.css
@@ -22,7 +22,6 @@
 
 .mdEditorCustom :global(.w-md-editor-preview) {
   box-shadow: none !important;
-  /* border-left: 1px solid #e0e0e0; */
 }
 
 .mdEditorCustom :global(.w-md-editor-toolbar) {

--- a/src/components/artifacts/TextRenderer.tsx
+++ b/src/components/artifacts/TextRenderer.tsx
@@ -1,7 +1,7 @@
+import { cleanContent } from "@/lib/normalize_string";
 import { Artifact } from "@/types";
 import MDEditor from "@uiw/react-md-editor";
 import { Dispatch, SetStateAction } from "react";
-import { cleanContent } from "@/lib/normalize_string";
 
 import styles from "./TextRenderer.module.css";
 
@@ -15,7 +15,7 @@ export interface TextRenderer {
 export function TextRenderer(props: TextRenderer) {
   return (
     <div
-      className="w-full h-full mt-2 flex flex-col border-[1px] border-gray-200 rounded-2xl overflow-hidden"
+      className="w-full h-full mt-2 flex flex-col border-t-[1px]   border-gray-200 overflow-hidden absolute"
       data-color-mode="light"
     >
       <MDEditor
@@ -24,7 +24,7 @@ export function TextRenderer(props: TextRenderer) {
         visibleDragbar={false}
         value={cleanContent(props.artifact.content)}
         onChange={(v) => props.setArtifactContent(props.artifact.id, v || "")}
-        className={`min-h-full border-none ${styles.mdEditorCustom} ${styles.fullHeightTextArea} ${styles.lightModeOnly}`}
+        className={`min-h-full border-none  ${styles.mdEditorCustom} ${styles.fullHeightTextArea} ${styles.lightModeOnly}`}
         height="100%"
       />
     </div>

--- a/src/components/artifacts/TextRenderer.tsx
+++ b/src/components/artifacts/TextRenderer.tsx
@@ -4,6 +4,7 @@ import MDEditor from "@uiw/react-md-editor";
 import { Dispatch, SetStateAction } from "react";
 
 import styles from "./TextRenderer.module.css";
+import { cn } from "@/lib/utils";
 
 export interface TextRenderer {
   artifact: Artifact;
@@ -24,7 +25,12 @@ export function TextRenderer(props: TextRenderer) {
         visibleDragbar={false}
         value={cleanContent(props.artifact.content)}
         onChange={(v) => props.setArtifactContent(props.artifact.id, v || "")}
-        className={`min-h-full border-none  ${styles.mdEditorCustom} ${styles.fullHeightTextArea} ${styles.lightModeOnly}`}
+        className={cn(
+          "min-h-full border-none",
+          styles.mdEditorCustom,
+          styles.fullHeightTextArea,
+          styles.lightModeOnly
+        )}
         height="100%"
       />
     </div>


### PR DESCRIPTION
This pull request addresses the issue of padding and borders in the markdown editor. The changes include:

1. Extended the markdown renderer to the bottom of the screen
2. Extended the markdown renderer to the left side of the screen
3. Removed borders on the bottom and left sides

Changes made:

- Updated **_ArtifactRenderer.tsx_** to remove left/right padding.
- Updated **_TextRenderer.tsx_** to make it renderer to the bottom of the screen
- Modified **_TextRenderer.module.css_** to adjust CSS/styling

## Screenshots:

### Before

![before-empty](https://github.com/user-attachments/assets/30ffeed7-6d51-47a2-997d-c9cc86a8a866)
![before-preview](https://github.com/user-attachments/assets/796c3a57-5503-4762-b5eb-ba41dc63ebcd)

### After

![after-empty](https://github.com/user-attachments/assets/1ba7e93d-f587-44f2-8a0b-61c6415d9ae6)
![after-preview](https://github.com/user-attachments/assets/b6238ee0-6d5d-43dc-a4cb-be63c2e34adb)

## Testing:

Tested on
 
- Microsoft Edge (Version 129.0.2792.89)
- Zen Browser (Version 1.0.1-a.10)

---

This is my first contribution to Open Canvas. Please let me know if any further changes or information are needed.

Fixes #55 