### PR TITLE
Fix: remove vercel KV from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,9 +8,5 @@ ANTHROPIC_API_KEY=
 # OpenAI used for content generation
 OPENAI_API_KEY=
 
-# Vercel KV stores. Used for system prompt storage.
-KV_REST_API_URL=
-KV_REST_API_TOKEN=
-
 # LangGraph Deployment, or local development server via LangGraph Studio.
 LANGGRAPH_API_URL=


### PR DESCRIPTION
Not used