### PR TITLE
Typo fix in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ LANGGRAPH_API_URL=
 # Supabase for authentication
 # Private key
 SUPABASE_SERVICE_ROLE_KEY=
-# Publuc keys
+# Public keys
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 


### PR DESCRIPTION
Trying to follow what the direction you're heading is - maybe get this working.