### PR TITLE
fix: clear empty user threads and store curr thread in cookies

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -23,12 +23,14 @@ export function Canvas(props: CanvasProps) {
     threadId,
     assistantId,
     createThread,
+    searchOrCreateThread,
     deleteThread,
     userThreads,
     isUserThreadsLoading,
     getUserThreads,
     setThreadId,
     getOrCreateAssistant,
+    clearThreadsWithNoValues,
   } = useThread(props.user.id);
   const [chatStarted, setChatStarted] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
@@ -54,12 +56,15 @@ export function Canvas(props: CanvasProps) {
     if (typeof window === "undefined") return;
 
     if (!threadId) {
-      createThread();
+      searchOrCreateThread(props.user.id);
     }
 
     if (!assistantId) {
       getOrCreateAssistant();
     }
+
+    // Clear threads with no values
+    clearThreadsWithNoValues(props.user.id);
   }, []);
 
   useEffect(() => {
@@ -83,7 +88,7 @@ export function Canvas(props: CanvasProps) {
   const createThreadWithChatStarted = async () => {
     setChatStarted(false);
     clearState();
-    return createThread();
+    return createThread(props.user.id);
   };
 
   const handleQuickStart = (

--- a/src/components/ThreadHistory.tsx
+++ b/src/components/ThreadHistory.tsx
@@ -195,7 +195,10 @@ export function ThreadHistory(props: ThreadHistoryProps) {
           <PiChatsCircleLight className="w-6 h-6 text-gray-600" />
         </TooltipIconButton>
       </SheetTrigger>
-      <SheetContent side="left" className="border-none">
+      <SheetContent
+        side="left"
+        className="border-none overflow-y-auto scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-gray-100"
+      >
         <p className="px-2 text-lg text-gray-600">Chat History</p>
         {props.isUserThreadsLoading && !props.userThreads.length ? (
           <div className="flex flex-col gap-1 px-2 pt-3">

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,3 +4,5 @@ export const LANGGRAPH_API_URL =
 export const ASSISTANT_ID_COOKIE = "oc_assistant_id_v2";
 // export const ASSISTANT_ID_COOKIE = "oc_assistant_id";
 export const HAS_ASSISTANT_COOKIE_BEEN_SET = "has_oc_assistant_id_been_set";
+export const THREAD_ID_COOKIE_NAME = "oc_thread_id_v2";
+export const HAS_EMPTY_THREADS_CLEARED_COOKIE = "has_empty_threads_cleared";

--- a/src/hooks/useGraph.tsx
+++ b/src/hooks/useGraph.tsx
@@ -600,6 +600,7 @@ export function useGraph(useGraphInput: UseGraphInput) {
     };
     if (!castValues?.messages?.length) {
       setMessages([]);
+      setArtifact(undefined);
       return;
     }
     setArtifact(castValues.artifact);

--- a/src/hooks/useGraph.tsx
+++ b/src/hooks/useGraph.tsx
@@ -600,7 +600,7 @@ export function useGraph(useGraphInput: UseGraphInput) {
     };
     if (!castValues?.messages?.length) {
       setMessages([]);
-      setArtifact(undefined);
+      setArtifact(castValues.artifact);
       return;
     }
     setArtifact(castValues.artifact);

--- a/src/hooks/useGraph.tsx
+++ b/src/hooks/useGraph.tsx
@@ -16,6 +16,8 @@ import { parsePartialJson } from "@langchain/core/output_parsers";
 import { useRuns } from "./useRuns";
 import { reverseCleanContent } from "@/lib/normalize_string";
 import { Thread } from "@langchain/langgraph-sdk";
+import { setCookie } from "@/lib/cookies";
+import { THREAD_ID_COOKIE_NAME } from "@/constants";
 // import { DEFAULT_ARTIFACTS, DEFAULT_MESSAGES } from "@/lib/dummy";
 
 interface ArtifactToolResponse {
@@ -591,6 +593,7 @@ export function useGraph(useGraphInput: UseGraphInput) {
     setThreadId: (id: string) => void
   ) => {
     setThreadId(thread.thread_id);
+    setCookie(THREAD_ID_COOKIE_NAME, thread.thread_id);
     const castValues = thread.values as {
       artifact?: Artifact;
       messages?: Record<string, any>[];

--- a/src/hooks/useThread.tsx
+++ b/src/hooks/useThread.tsx
@@ -1,7 +1,11 @@
 import { useState } from "react";
 import { createClient } from "./utils";
 import { getCookie, setCookie } from "@/lib/cookies";
-import { ASSISTANT_ID_COOKIE } from "@/constants";
+import {
+  ASSISTANT_ID_COOKIE,
+  HAS_EMPTY_THREADS_CLEARED_COOKIE,
+  THREAD_ID_COOKIE_NAME,
+} from "@/constants";
 import { Thread } from "@langchain/langgraph-sdk";
 
 export function useThread(userId: string) {
@@ -10,15 +14,15 @@ export function useThread(userId: string) {
   const [userThreads, setUserThreads] = useState<Thread[]>([]);
   const [isUserThreadsLoading, setIsUserThreadsLoading] = useState(false);
 
-  const createThread = async (clearState?: () => void) => {
-    clearState?.();
+  const createThread = async (supabaseUserId: string) => {
     const client = createClient();
     const thread = await client.threads.create({
       metadata: {
-        supabase_user_id: userId,
+        supabase_user_id: supabaseUserId,
       },
     });
     setThreadId(thread.thread_id);
+    setCookie(THREAD_ID_COOKIE_NAME, thread.thread_id);
     await getUserThreads(userId);
     return thread;
   };
@@ -62,6 +66,90 @@ export function useThread(userId: string) {
     }
   };
 
+  const searchOrCreateThread = async (id: string) => {
+    const threadIdCookie = getCookie(THREAD_ID_COOKIE_NAME);
+    if (!threadIdCookie) {
+      await createThread(id);
+      return;
+    }
+
+    // Thread ID is in cookies.
+    const thread = await getThreadById(threadIdCookie);
+    if (!thread.values || Object.keys(thread.values).length === 0) {
+      // No values = no activity. Can keep.
+      setThreadId(threadIdCookie);
+      return;
+    } else {
+      // Current thread has activity. Create a new thread.
+      await createThread(id);
+      return;
+    }
+  };
+
+  const clearThreadsWithNoValues = async (userId: string) => {
+    const hasBeenClearedCookie = getCookie(HAS_EMPTY_THREADS_CLEARED_COOKIE);
+    if (hasBeenClearedCookie === "true") {
+      return;
+    }
+
+    const client = createClient();
+    const processedThreadIds = new Set<string>();
+
+    const fetchAndDeleteThreads = async (offset = 0) => {
+      const userThreads = await client.threads.search({
+        metadata: {
+          supabase_user_id: userId,
+        },
+        limit: 100,
+        offset: offset,
+      });
+
+      const threadsToDelete = userThreads.filter(
+        (thread) =>
+          !thread.values &&
+          thread.thread_id !== threadId &&
+          !processedThreadIds.has(thread.thread_id)
+      );
+
+      if (threadsToDelete.length > 0) {
+        const deleteBatch = async (threadIds: string[]) => {
+          await Promise.all(
+            threadIds.map(async (threadId) => {
+              await client.threads.delete(threadId);
+              processedThreadIds.add(threadId);
+            })
+          );
+        };
+
+        // Create an array of unique thread IDs
+        const uniqueThreadIds = Array.from(
+          new Set(threadsToDelete.map((thread) => thread.thread_id))
+        );
+
+        // Process unique thread IDs in batches of 10
+        for (let i = 0; i < uniqueThreadIds.length; i += 10) {
+          try {
+            await deleteBatch(uniqueThreadIds.slice(i, i + 10));
+          } catch (e) {
+            console.error("Error deleting threads", e);
+          }
+        }
+      }
+
+      if (userThreads.length === 100) {
+        // If we got 100 threads, there might be more, so continue fetching
+        await fetchAndDeleteThreads(offset + 100);
+      }
+    };
+
+    try {
+      await fetchAndDeleteThreads();
+      setCookie(HAS_EMPTY_THREADS_CLEARED_COOKIE, "true");
+    } catch (e) {
+      console.error("Error fetching & deleting threads", e);
+    }
+  };
+
   const getThreadById = async (id: string) => {
     const client = createClient();
     return await client.threads.get(id);
@@ -80,19 +168,20 @@ export function useThread(userId: string) {
     if (id === threadId) {
       clearMessages();
       // Create a new thread. Use .then to avoid blocking the UI.
-      // Once completed re-fetch threads to update UI.
-      createThread().then(async () => {
-        await getUserThreads(userId);
-      });
+      // Once completed, `createThread` will re-fetch all user
+      // threads to update UI.
+      void createThread(userId);
     }
     const client = createClient();
     await client.threads.delete(id);
   };
 
   return {
+    clearThreadsWithNoValues,
     threadId,
     assistantId,
     createThread,
+    searchOrCreateThread,
     getUserThreads,
     userThreads,
     isUserThreadsLoading,


### PR DESCRIPTION
This allows us to not create a new thread on every page load, unless the last created thread was used.