### PR TITLE
Feat: Add support for GPT 4o mini Azure model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ NEXT_PUBLIC_FIREWORKS_ENABLED=true
 NEXT_PUBLIC_GEMINI_ENABLED=false
 NEXT_PUBLIC_ANTHROPIC_ENABLED=true
 NEXT_PUBLIC_OPENAI_ENABLED=true
+NEXT_PUBLIC_AZURE_ENABLED=false
 
 # LangGraph Deployment, or local development server via LangGraph Studio.
 # If running locally, this URL should be set in the `constants.ts` file.
@@ -25,3 +26,12 @@ NEXT_PUBLIC_OPENAI_ENABLED=true
 # Public keys
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
+
+# Azure OpenAI Configuration
+AZURE_OPENAI_API_KEY=your-azure-openai-api-key
+AZURE_OPENAI_API_INSTANCE_NAME=your-instance-name
+AZURE_OPENAI_API_DEPLOYMENT_NAME=your-deployment-name
+AZURE_OPENAI_API_VERSION=2024-08-01-preview
+
+# Optional: Azure OpenAI Base Path (if using a different domain)
+# AZURE_OPENAI_BASE_PATH=https://your-custom-domain.com/openai/deployments

--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,5 @@ AZURE_OPENAI_API_KEY=your-azure-openai-api-key
 AZURE_OPENAI_API_INSTANCE_NAME=your-instance-name
 AZURE_OPENAI_API_DEPLOYMENT_NAME=your-deployment-name
 AZURE_OPENAI_API_VERSION=2024-08-01-preview
-
 # Optional: Azure OpenAI Base Path (if using a different domain)
-# AZURE_OPENAI_BASE_PATH=https://your-custom-domain.com/openai/deployments
+# AZURE_OPENAI_API_BASE_PATH=https://your-custom-domain.com/openai/deployments

--- a/src/agent/open-canvas/nodes/customAction.ts
+++ b/src/agent/open-canvas/nodes/customAction.ts
@@ -1,6 +1,6 @@
 import { BaseMessage } from "@langchain/core/messages";
 import { LangGraphRunnableConfig } from "@langchain/langgraph";
-import { initChatModel } from "langchain/chat_models/universal";
+import { initChatModelWithConfig, getModelConfig } from "../../utils";
 import { getArtifactContent } from "../../../contexts/utils";
 import { isArtifactMarkdownContent } from "../../../lib/artifact_content_types";
 import {
@@ -10,11 +10,7 @@ import {
   CustomQuickAction,
   Reflections,
 } from "../../../types";
-import {
-  ensureStoreInConfig,
-  formatReflections,
-  getModelNameAndProviderFromConfig,
-} from "../../utils";
+import { ensureStoreInConfig, formatReflections } from "../../utils";
 import {
   CUSTOM_QUICK_ACTION_ARTIFACT_CONTENT_PROMPT,
   CUSTOM_QUICK_ACTION_ARTIFACT_PROMPT_PREFIX,
@@ -39,11 +35,11 @@ export const customAction = async (
     throw new Error("No custom quick action ID found.");
   }
 
-  const { modelName, modelProvider } =
-    getModelNameAndProviderFromConfig(config);
-  const smallModel = await initChatModel(modelName, {
+  const { modelName, modelProvider, azureConfig } = getModelConfig(config);
+  const smallModel = await initChatModelWithConfig(modelName, {
     temperature: 0.5,
     modelProvider,
+    azureConfig,
   });
 
   const store = ensureStoreInConfig(config);

--- a/src/agent/open-canvas/nodes/generateArtifact.ts
+++ b/src/agent/open-canvas/nodes/generateArtifact.ts
@@ -11,10 +11,10 @@ import { z } from "zod";
 import {
   ensureStoreInConfig,
   formatReflections,
-  getModelNameAndProviderFromConfig,
+  getModelConfig,
+  initChatModelWithConfig,
 } from "../../utils";
 import { LangGraphRunnableConfig } from "@langchain/langgraph";
-import { initChatModel } from "langchain/chat_models/universal";
 
 /**
  * Generate a new artifact based on the user's query.
@@ -23,11 +23,11 @@ export const generateArtifact = async (
   state: typeof OpenCanvasGraphAnnotation.State,
   config: LangGraphRunnableConfig
 ): Promise<OpenCanvasGraphReturnType> => {
-  const { modelName, modelProvider } =
-    getModelNameAndProviderFromConfig(config);
-  const smallModel = await initChatModel(modelName, {
+  const { modelName, modelProvider, azureConfig } = getModelConfig(config);
+  const smallModel = await initChatModelWithConfig(modelName, {
     temperature: 0.5,
     modelProvider,
+    azureConfig,
   });
 
   const store = ensureStoreInConfig(config);

--- a/src/agent/open-canvas/nodes/generateFollowup.ts
+++ b/src/agent/open-canvas/nodes/generateFollowup.ts
@@ -1,13 +1,9 @@
 import { LangGraphRunnableConfig } from "@langchain/langgraph";
-import { initChatModel } from "langchain/chat_models/universal";
+import { initChatModelWithConfig, getModelConfig } from "../../utils";
 import { getArtifactContent } from "../../../contexts/utils";
 import { isArtifactMarkdownContent } from "../../../lib/artifact_content_types";
 import { Reflections } from "../../../types";
-import {
-  ensureStoreInConfig,
-  formatReflections,
-  getModelNameAndProviderFromConfig,
-} from "../../utils";
+import { ensureStoreInConfig, formatReflections } from "../../utils";
 import { FOLLOWUP_ARTIFACT_PROMPT } from "../prompts";
 import { OpenCanvasGraphAnnotation, OpenCanvasGraphReturnType } from "../state";
 
@@ -18,12 +14,12 @@ export const generateFollowup = async (
   state: typeof OpenCanvasGraphAnnotation.State,
   config: LangGraphRunnableConfig
 ): Promise<OpenCanvasGraphReturnType> => {
-  const { modelName, modelProvider } =
-    getModelNameAndProviderFromConfig(config);
-  const smallModel = await initChatModel(modelName, {
+  const { modelName, modelProvider, azureConfig } = getModelConfig(config);
+  const smallModel = await initChatModelWithConfig(modelName, {
     temperature: 0.5,
     maxTokens: 250,
     modelProvider,
+    azureConfig,
   });
 
   const store = ensureStoreInConfig(config);

--- a/src/agent/open-canvas/nodes/generatePath.ts
+++ b/src/agent/open-canvas/nodes/generatePath.ts
@@ -7,12 +7,9 @@ import {
 } from "../prompts";
 import { OpenCanvasGraphAnnotation } from "../state";
 import { z } from "zod";
-import {
-  formatArtifactContentWithTemplate,
-  getModelNameAndProviderFromConfig,
-} from "../../utils";
+import { formatArtifactContentWithTemplate, getModelConfig } from "../../utils";
 import { getArtifactContent } from "../../../contexts/utils";
-import { initChatModel } from "langchain/chat_models/universal";
+import { initChatModelWithConfig } from "../../utils";
 import { LangGraphRunnableConfig } from "@langchain/langgraph";
 
 /**
@@ -93,11 +90,11 @@ export const generatePath = async (
     ? "rewriteArtifact"
     : "generateArtifact";
 
-  const { modelName, modelProvider } =
-    getModelNameAndProviderFromConfig(config);
-  const model = await initChatModel(modelName, {
+  const { modelName, modelProvider, azureConfig } = getModelConfig(config);
+  const model = await initChatModelWithConfig(modelName, {
     temperature: 0,
     modelProvider,
+    azureConfig,
   });
   const modelWithTool = model.withStructuredOutput(
     z.object({

--- a/src/agent/open-canvas/nodes/replyToGeneralInput.ts
+++ b/src/agent/open-canvas/nodes/replyToGeneralInput.ts
@@ -1,12 +1,11 @@
 import { LangGraphRunnableConfig } from "@langchain/langgraph";
-import { initChatModel } from "langchain/chat_models/universal";
+import { initChatModelWithConfig, getModelConfig } from "../../utils";
 import { getArtifactContent } from "../../../contexts/utils";
 import { Reflections } from "../../../types";
 import {
   ensureStoreInConfig,
   formatArtifactContentWithTemplate,
   formatReflections,
-  getModelNameAndProviderFromConfig,
 } from "../../utils";
 import { CURRENT_ARTIFACT_PROMPT, NO_ARTIFACT_PROMPT } from "../prompts";
 import { OpenCanvasGraphAnnotation, OpenCanvasGraphReturnType } from "../state";
@@ -18,11 +17,11 @@ export const replyToGeneralInput = async (
   state: typeof OpenCanvasGraphAnnotation.State,
   config: LangGraphRunnableConfig
 ): Promise<OpenCanvasGraphReturnType> => {
-  const { modelName, modelProvider } =
-    getModelNameAndProviderFromConfig(config);
-  const smallModel = await initChatModel(modelName, {
+  const { modelName, modelProvider, azureConfig } = getModelConfig(config);
+  const smallModel = await initChatModelWithConfig(modelName, {
     temperature: 0.5,
     modelProvider,
+    azureConfig,
   });
 
   const prompt = `You are an AI assistant tasked with responding to the users question.

--- a/src/agent/open-canvas/nodes/rewriteArtifactTheme.ts
+++ b/src/agent/open-canvas/nodes/rewriteArtifactTheme.ts
@@ -1,13 +1,9 @@
 import { LangGraphRunnableConfig } from "@langchain/langgraph";
-import { initChatModel } from "langchain/chat_models/universal";
+import { initChatModelWithConfig, getModelConfig } from "../../utils";
 import { getArtifactContent } from "../../../contexts/utils";
 import { isArtifactMarkdownContent } from "../../../lib/artifact_content_types";
 import { ArtifactV3, Reflections } from "../../../types";
-import {
-  ensureStoreInConfig,
-  formatReflections,
-  getModelNameAndProviderFromConfig,
-} from "../../utils";
+import { ensureStoreInConfig, formatReflections } from "../../utils";
 import {
   ADD_EMOJIS_TO_ARTIFACT_PROMPT,
   CHANGE_ARTIFACT_LANGUAGE_PROMPT,
@@ -21,11 +17,11 @@ export const rewriteArtifactTheme = async (
   state: typeof OpenCanvasGraphAnnotation.State,
   config: LangGraphRunnableConfig
 ): Promise<OpenCanvasGraphReturnType> => {
-  const { modelName, modelProvider } =
-    getModelNameAndProviderFromConfig(config);
-  const smallModel = await initChatModel(modelName, {
+  const { modelName, modelProvider, azureConfig } = getModelConfig(config);
+  const smallModel = await initChatModelWithConfig(modelName, {
     temperature: 0.5,
     modelProvider,
+    azureConfig,
   });
 
   const store = ensureStoreInConfig(config);

--- a/src/agent/open-canvas/nodes/rewriteCodeArtifactTheme.ts
+++ b/src/agent/open-canvas/nodes/rewriteCodeArtifactTheme.ts
@@ -1,6 +1,6 @@
-import { getModelNameAndProviderFromConfig } from "@/agent/utils";
+import { getModelConfig } from "@/agent/utils";
 import { LangGraphRunnableConfig } from "@langchain/langgraph";
-import { initChatModel } from "langchain/chat_models/universal";
+import { initChatModelWithConfig } from "../../utils";
 import { getArtifactContent } from "../../../contexts/utils";
 import { isArtifactCodeContent } from "../../../lib/artifact_content_types";
 import { ArtifactCodeV3, ArtifactV3 } from "../../../types";
@@ -16,11 +16,11 @@ export const rewriteCodeArtifactTheme = async (
   state: typeof OpenCanvasGraphAnnotation.State,
   config: LangGraphRunnableConfig
 ): Promise<OpenCanvasGraphReturnType> => {
-  const { modelName, modelProvider } =
-    getModelNameAndProviderFromConfig(config);
-  const smallModel = await initChatModel(modelName, {
+  const { modelName, modelProvider, azureConfig } = getModelConfig(config);
+  const smallModel = await initChatModelWithConfig(modelName, {
     temperature: 0.5,
     modelProvider,
+    azureConfig,
   });
 
   const currentArtifactContent = state.artifact

--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -1,19 +1,12 @@
 import { isArtifactCodeContent } from "@/lib/artifact_content_types";
 import { BaseStore, LangGraphRunnableConfig } from "@langchain/langgraph";
-import { ArtifactCodeV3, ArtifactMarkdownV3, Reflections } from "../types";
+import {
+  ArtifactCodeV3,
+  ArtifactMarkdownV3,
+  Reflections,
+  ModelConfig,
+} from "../types";
 import { initChatModel } from "langchain/chat_models/universal";
-
-type ModelConfig = {
-  temperature?: number;
-  modelProvider: string;
-  maxTokens?: number;
-  azureConfig?: {
-    azureOpenAIApiKey: string;
-    azureOpenAIApiInstanceName: string;
-    azureOpenAIApiDeploymentName: string;
-    azureOpenAIApiVersion: string;
-  };
-};
 
 /**
  * Wrapper around initChatModel

--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -34,6 +34,7 @@ export const initChatModelWithConfig = async (
           azureOpenAIApiDeploymentName:
             config.azureConfig.azureOpenAIApiDeploymentName,
           azureOpenAIApiVersion: config.azureConfig.azureOpenAIApiVersion,
+          azureOpenAIBasePath: config.azureConfig.azureOpenAIBasePath,
         }
       : {}),
   });
@@ -159,6 +160,7 @@ export const getModelConfig = (
     azureOpenAIApiInstanceName: string;
     azureOpenAIApiDeploymentName: string;
     azureOpenAIApiVersion: string;
+    azureOpenAIBasePath?: string;
   };
 } => {
   const customModelName = config.configurable?.customModelName as string;
@@ -166,7 +168,6 @@ export const getModelConfig = (
     throw new Error("Model name is missing in config.");
   }
 
-  // Handle Azure OpenAI models
   if (customModelName.startsWith("azure/")) {
     const actualModelName = customModelName.replace("azure/", "");
     return {
@@ -180,11 +181,11 @@ export const getModelConfig = (
           process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME || "",
         azureOpenAIApiVersion:
           process.env.AZURE_OPENAI_API_VERSION || "2024-08-01-preview",
+        azureOpenAIBasePath: process.env.AZURE_OPENAI_API_BASE_PATH,
       },
     };
   }
 
-  // Handle existing model providers
   if (customModelName.includes("gpt-")) {
     return {
       modelName: customModelName,

--- a/src/agent/utils.ts
+++ b/src/agent/utils.ts
@@ -179,7 +179,7 @@ export const getModelConfig = (
         azureOpenAIApiDeploymentName:
           process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME || "",
         azureOpenAIApiVersion:
-          process.env.AZURE_OPENAI_API_VERSION || "2024-02-01",
+          process.env.AZURE_OPENAI_API_VERSION || "2024-08-01-preview",
       },
     };
   }

--- a/src/components/chat-interface/model-selector.tsx
+++ b/src/components/chat-interface/model-selector.tsx
@@ -17,6 +17,7 @@ import {
   FIREWORKS_MODELS,
   GEMINI_MODELS,
   LS_HAS_SEEN_MODEL_DROPDOWN_ALERT,
+  AZURE_MODELS,
 } from "@/constants";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -29,6 +30,7 @@ const allModels = [
   ...OPENAI_MODELS,
   ...FIREWORKS_MODELS,
   ...GEMINI_MODELS,
+  ...AZURE_MODELS,
 ];
 
 const modelNameToLabel = (modelName: ALL_MODEL_NAMES) => {
@@ -173,6 +175,12 @@ export default function ModelSelector(props: ModelSelectorProps) {
     if (
       model.name.includes("gpt-") &&
       process.env.NEXT_PUBLIC_OPENAI_ENABLED === "false"
+    ) {
+      return false;
+    }
+    if (
+      model.name.includes("azure") &&
+      process.env.NEXT_PUBLIC_AZURE_ENABLED === "false"
     ) {
       return false;
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,6 +23,13 @@ export const DEFAULT_INPUTS = {
   customQuickActionId: undefined,
 };
 
+export const AZURE_MODELS = [
+  {
+    name: "azure/gpt-4o-mini",
+    label: "GPT-4o mini (Azure)",
+  },
+];
+
 export const OPENAI_MODELS = [
   {
     name: "gpt-4o-mini",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,7 @@ export const DEFAULT_INPUTS = {
 export const AZURE_MODELS = [
   {
     name: "azure/gpt-4o-mini",
+    actualName: "gpt-4o-mini",
     label: "GPT-4o mini (Azure)",
   },
 ];
@@ -65,7 +66,7 @@ export type OPENAI_MODEL_NAMES = (typeof OPENAI_MODELS)[number]["name"];
 export type ANTHROPIC_MODEL_NAMES = (typeof ANTHROPIC_MODELS)[number]["name"];
 export type FIREWORKS_MODEL_NAMES = (typeof FIREWORKS_MODELS)[number]["name"];
 export type GEMINI_MODEL_NAMES = (typeof GEMINI_MODELS)[number]["name"];
-export type AZURE_MODEL_NAMES = (typeof AZURE_MODELS)[number]["name"];
+export type AZURE_MODEL_NAMES = (typeof AZURE_MODELS)[number]["actualName"];
 export type ALL_MODEL_NAMES =
   | OPENAI_MODEL_NAMES
   | ANTHROPIC_MODEL_NAMES

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,6 +36,7 @@ export const OPENAI_MODELS = [
     label: "GPT-4o mini",
   },
 ];
+
 export const ANTHROPIC_MODELS = [
   {
     name: "claude-3-haiku-20240307",
@@ -64,8 +65,10 @@ export type OPENAI_MODEL_NAMES = (typeof OPENAI_MODELS)[number]["name"];
 export type ANTHROPIC_MODEL_NAMES = (typeof ANTHROPIC_MODELS)[number]["name"];
 export type FIREWORKS_MODEL_NAMES = (typeof FIREWORKS_MODELS)[number]["name"];
 export type GEMINI_MODEL_NAMES = (typeof GEMINI_MODELS)[number]["name"];
+export type AZURE_MODEL_NAMES = (typeof AZURE_MODELS)[number]["name"];
 export type ALL_MODEL_NAMES =
   | OPENAI_MODEL_NAMES
   | ANTHROPIC_MODEL_NAMES
   | FIREWORKS_MODEL_NAMES
-  | GEMINI_MODEL_NAMES;
+  | GEMINI_MODEL_NAMES
+  | AZURE_MODEL_NAMES;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,7 +26,7 @@ export const DEFAULT_INPUTS = {
 export const AZURE_MODELS = [
   {
     name: "azure/gpt-4o-mini",
-    actualName: "gpt-4o-mini",
+    modelName: "gpt-4o-mini",
     label: "GPT-4o mini (Azure)",
   },
 ];
@@ -66,7 +66,7 @@ export type OPENAI_MODEL_NAMES = (typeof OPENAI_MODELS)[number]["name"];
 export type ANTHROPIC_MODEL_NAMES = (typeof ANTHROPIC_MODELS)[number]["name"];
 export type FIREWORKS_MODEL_NAMES = (typeof FIREWORKS_MODELS)[number]["name"];
 export type GEMINI_MODEL_NAMES = (typeof GEMINI_MODELS)[number]["name"];
-export type AZURE_MODEL_NAMES = (typeof AZURE_MODELS)[number]["actualName"];
+export type AZURE_MODEL_NAMES = (typeof AZURE_MODELS)[number]["modelName"];
 export type ALL_MODEL_NAMES =
   | OPENAI_MODEL_NAMES
   | ANTHROPIC_MODEL_NAMES

--- a/src/hooks/useThread.tsx
+++ b/src/hooks/useThread.tsx
@@ -23,9 +23,6 @@ export function useThread() {
     userId: string
   ): Promise<Thread | undefined> => {
     const client = createClient();
-    if (customModelName.includes("azure/")) {
-      customModelName = customModelName.replace("azure/", "");
-    }
     try {
       const thread = await client.threads.create({
         metadata: {

--- a/src/hooks/useThread.tsx
+++ b/src/hooks/useThread.tsx
@@ -23,6 +23,9 @@ export function useThread() {
     userId: string
   ): Promise<Thread | undefined> => {
     const client = createClient();
+    if (customModelName.includes("azure/")) {
+      customModelName = customModelName.replace("azure/", "");
+    }
     try {
       const thread = await client.threads.create({
         metadata: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -265,3 +265,16 @@ export type RewriteArtifactMetaToolResponse =
       title: string;
       language: ProgrammingLanguageOptions;
     };
+
+export interface ModelConfig {
+  temperature?: number;
+  modelProvider: string;
+  maxTokens?: number;
+  azureConfig?: {
+    azureOpenAIApiKey: string;
+    azureOpenAIApiInstanceName: string;
+    azureOpenAIApiDeploymentName: string;
+    azureOpenAIApiVersion: string;
+    azureOpenAIBasePath?: string;
+  };
+}


### PR DESCRIPTION
**Change:** Added support for gpt-4o-mini azure openai model. Resolves https://github.com/langchain-ai/open-canvas/issues/102 

**Changes:**
- Added azure models to the list of existing models
- Created a wrapper to call `initChatModel`
- Added required config for passing azure credentials 
- Updated `.env.example` with required azure env variables for using it
- Updated agents to read optional azureConfig being passed and pass on to `initChatModelWithConfig`

**Evidence:**

https://github.com/user-attachments/assets/cc000e59-d4b8-4bea-b52d-ae3c41398cbb




