### PR TITLE
add LANGSMITH_TRACING=false in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 LANGCHAIN_TRACING_V2=true
 LANGCHAIN_API_KEY=
 
+# disable trace or log upload to Langchain platform
+LANGSMITH_TRACING=false
+
 # LLM API keys
 # Anthropic used for reflection
 ANTHROPIC_API_KEY=


### PR DESCRIPTION
https://github.com/langchain-ai/open-canvas/issues/211

Disable should be the default. I've spent hours trying to disable it.

Note: this doesn't disable langgraph. You still, sadly, still need to run `langgraph up` and docker