### PR TITLE
Fix Installation Circular Dependency Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,13 @@ Next, install the dependencies:
 yarn install
 ```
 
-After installing dependencies, copy the contents of both `.env.example` files in the root of the project, and in `apps/web` into `.env` and set the required values:
+After installing dependencies, build the project:
+
+```bash
+yarn build
+```
+
+Then, copy the contents of both `.env.example` files in the root of the project, and in `apps/web` into `.env` and set the required values:
 
 ```bash
 # The root `.env` file will be read by the LangGraph server for the agents.

--- a/apps/agents/package.json
+++ b/apps/agents/package.json
@@ -17,8 +17,7 @@
     "clean": "rm -rf ./dist .turbo || true",
     "format": "prettier --config .prettierrc --write \"src\"",
     "lint": "eslint src",
-    "lint:fix": "eslint src --fix",
-    "postinstall": "yarn turbo build"
+    "lint:fix": "eslint src --fix"
   },
   "dependencies": {
     "@ffmpeg/ffmpeg": "^0.12.15",


### PR DESCRIPTION
# Fix Installation Circular Dependency Issue

## Problem
When running `yarn install`, users encounter a circular dependency error because the @opencanvas/agents package tries to run `yarn turbo build` during installation via its postinstall script. This creates a circular dependency since:
1. The postinstall script tries to use Turbo to build the package
2. But Turbo itself isn't fully available during the installation process
3. This results in a "Cannot find module 'turbo'" error that blocks installation

## Solution
This PR fixes the installation process by:
1. Removing the problematic postinstall script from apps/agents/package.json that was causing the circular dependency
2. Updating the main README.md to include an explicit `yarn build` step after installation
3. Ensuring the build process is run manually after dependency installation instead of during the installation itself

This breaks the circular dependency chain and allows for a smooth installation experience for new contributors.

## Changes
- Removed the postinstall script from apps/agents/package.json
- Updated README.md to add the explicit build step after yarn install

These changes ensure that Open Canvas can be installed without errors and maintains a clear, straightforward setup process for new users.